### PR TITLE
fix(DIS-522): configure terraform state storage and retrieval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,8 +206,6 @@ jobs:
           echo "Running terraform init..."
           terraform init
         working-directory: apps/service-iac
-        with:
-          credentials_json: ${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}
 
       - name: Terraform validate
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release
 on:
   push:
     branches:
-      - bugfix/DIS-522-fly-app-already-exists
+      - bugfix/DIS-522-configure-terraform-state-storage-and-retrieval
 
 # Set environment variable to disable Husky
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
       #     terraform plan -out=tfplan
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,6 @@ jobs:
       #   uses: hashicorp/setup-terraform@v1
       #   with:
       #     terraform_version: 1.3.9 # Update this to the desired Terraform version
-
       # - name: Terraform Apply
       #   if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
       #   env:
@@ -181,12 +180,13 @@ jobs:
       #     terraform init
       #     terraform validate
       #     terraform plan -out=tfplan
-
       # https://github.com/google-github-actions/setup-gcloud
       - name: "Setup GCP SKD Auth"
-        uses: "google-github-actions/auth@v1"
-        with:
-          credentials_json: "${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}"
+        run: |
+          echo '${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}' > gcp_sa_key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcp_sa_key.json" >> $GITHUB_ENV
+        # with:
+        #   credentials_json: "${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}"
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,13 @@ jobs:
       #     terraform validate
       #     terraform plan -out=tfplan
 
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release
 on:
   push:
     branches:
-      - bugfix/DIS-522-configure-terraform-state-storage-and-retrieval
+      - trunk
 
 # Set environment variable to disable Husky
 env:
@@ -144,49 +144,32 @@ jobs:
           git remote set-url origin "https://${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}@github.com/amaralc/peerlab.git"
           git remote -v
 
-      # - name: Release Step
-      #   if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
-      #   run: |
-      #     git status
-      #     git diff
-      #     yarn git:discard:all
-      #     git status
-      #     git diff
-      #     git config --global user.name "${{ github.actor }}"
-      #     git config --global user.email "${{ github.actor}}@users.noreply.github.com"
-      #     # echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}" >> .npmrc
-      #     yarn release
+      - name: Release Step
+        if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git status
+          git diff
+          yarn git:discard:all
+          git status
+          git diff
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor}}@users.noreply.github.com"
+          # echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}" >> .npmrc
+          yarn release
 
       - name: Configure Fly CLI
         run: |
           mkdir -p ~/.fly
           echo "api_key = \"$FLY_API_TOKEN\"" > ~/.fly/config.toml
 
-      # - name: Setup Terraform
-      #   uses: hashicorp/setup-terraform@v1
-      #   with:
-      #     terraform_version: 1.3.9 # Update this to the desired Terraform version
-      # - name: Terraform Apply
-      #   if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-      #   env:
-      #     FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      #     TF_VAR_database_url: ${{ secrets.TF_VAR_database_url }}
-      #     TF_VAR_direct_url: ${{ secrets.TF_VAR_direct_url }}
-      #   run: |
-      #     cd apps/service-iac
-      #     terraform init
-      #     terraform validate
-      #     terraform plan -out=tfplan
       # https://github.com/google-github-actions/setup-gcloud
       - name: "Setup GCP SKD Auth"
         run: |
           echo '${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}' > gcp_sa_key.json
           echo "GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcp_sa_key.json" >> $GITHUB_ENV
-        # with:
-        #   credentials_json: "${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}"
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
           echo "Running terraform init..."
           terraform init
         working-directory: apps/service-iac
+        with:
+          credentials_json: ${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}
 
       - name: Terraform validate
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,12 +182,14 @@ jobs:
       #     terraform validate
       #     terraform plan -out=tfplan
 
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+      # https://github.com/google-github-actions/setup-gcloud
+      - name: "Setup GCP SKD Auth"
+        uses: "google-github-actions/auth@v1"
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: "${{ secrets.GCP_STORAGE_SERVICE_ACCOUNT_KEYS }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release
 on:
   push:
     branches:
-      - trunk
+      - bugfix/DIS-522-fly-app-already-exists
 
 # Set environment variable to disable Husky
 env:
@@ -144,21 +144,21 @@ jobs:
           git remote set-url origin "https://${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}@github.com/amaralc/peerlab.git"
           git remote -v
 
-      - name: Release Step
-        if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
-        run: |
-          git status
-          git diff
-          yarn git:discard:all
-          git status
-          git diff
-          git config --global user.name "${{ github.actor }}"
-          git config --global user.email "${{ github.actor}}@users.noreply.github.com"
-          # echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}" >> .npmrc
-          yarn release
+      # - name: Release Step
+      #   if: ${{ success() && (github.event_name != 'pull_request' || github.event.action == 'closed' && github.event.pull_request.merged == true) }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}
+      #   run: |
+      #     git status
+      #     git diff
+      #     yarn git:discard:all
+      #     git status
+      #     git diff
+      #     git config --global user.name "${{ github.actor }}"
+      #     git config --global user.email "${{ github.actor}}@users.noreply.github.com"
+      #     # echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_ACTIONS_PERSONAL_ACCESS_TOKEN }}" >> .npmrc
+      #     yarn release
 
       - name: Configure Fly CLI
         run: |

--- a/apps/service-iac/main.tf
+++ b/apps/service-iac/main.tf
@@ -97,6 +97,9 @@ resource "fly_machine" "micro_app_machine_01" {
   region = each.value
   name   = "${local.app_name}-${each.value}"
   image  = "registry.fly.io/${local.app_name}:${local.image_tag}"
+  # env = {
+  #   DATABASE_PROVIDER = "value"
+  # }
   services = [
     {
       ports = [

--- a/apps/service-iac/main.tf
+++ b/apps/service-iac/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  backend "gcs" {
+    bucket      = "peerlab-terraform-state"
+    prefix      = "terraform/state"
+    credentials = "path/to/your/credentials.json"
+  }
+}
+
 # Configure the Fly provider
 provider "fly" {
   useinternaltunnel    = true

--- a/apps/service-iac/main.tf
+++ b/apps/service-iac/main.tf
@@ -1,8 +1,7 @@
 terraform {
   backend "gcs" {
-    bucket      = "peerlab-terraform-state"
-    prefix      = "terraform/state"
-    credentials = file(getenv("GCP_STORAGE_SERVICE_ACCOUNT_KEYS"))
+    bucket = "peerlab-terraform-state"
+    prefix = "terraform/state"
   }
 }
 

--- a/apps/service-iac/main.tf
+++ b/apps/service-iac/main.tf
@@ -2,7 +2,7 @@ terraform {
   backend "gcs" {
     bucket      = "peerlab-terraform-state"
     prefix      = "terraform/state"
-    credentials = "path/to/your/credentials.json"
+    credentials = file(getenv("GCP_STORAGE_SERVICE_ACCOUNT_KEYS"))
   }
 }
 

--- a/apps/service-rest-api/Dockerfile
+++ b/apps/service-rest-api/Dockerfile
@@ -70,6 +70,17 @@ FROM base
 
 ENV PORT="8080"
 ENV NODE_ENV="production"
+## Database provider ("mongodb-mongoose-orm" | "postgresql-prisma-orm" | "postgresql-type-orm" |  "in-memory")
+ENV DATABASE_PROVIDER=postgresql-prisma-orm
+
+## Events provider ('kafka' | 'in-memory')
+ENV EVENTS_PROVIDER=in-memory
+
+## Transporter ('nestjs-default-kafka-transporter' | 'nestjs-custom-kafka-transporter' | 'simple-kafka-transporter')
+ENV EVENTS_TRANSPORTER=nestjs-default-kafka-transporter
+
+## Auth
+ENV API_KEY=my-secret-api-key
 
 WORKDIR /app/
 COPY package.json yarn.lock ./

--- a/libs/adapters/src/config.dto.ts
+++ b/libs/adapters/src/config.dto.ts
@@ -12,7 +12,7 @@ class ConfigDto {
   // Events
   nestJsMicroservicesOptions?: NestApplicationContextOptions & MicroserviceOptions;
   eventsConsumerPort = 3000; // Specify process to avoid conflicts with rest-api port (nestjs default port is 3000)
-  eventsProvider = (process.env['EVENTS_PROVIDER'] as IEventsProvider) || 'kafka';
+  eventsProvider = (process.env['EVENTS_PROVIDER'] as IEventsProvider) || 'in-memory';
   eventsTransporter = (process.env['EVENTS_TRANSPORTER'] as ITransporter) || 'simple-kafka-transporter';
   kafkaBroker = process.env['KAFKA_BROKER'] || 'localhost:9092';
   kafkaClientId = process.env['KAFKA_CLIENT_ID'] || 'micro-applications-template-client-id';

--- a/libs/adapters/src/controllers/api/routes/peers/controller.ts
+++ b/libs/adapters/src/controllers/api/routes/peers/controller.ts
@@ -32,6 +32,11 @@ export class PeersRestController {
     return { peers };
   }
 
+  @Get('/mock')
+  async getMock() {
+    return { peers: [{ id: 'mock-peer', name: 'mock-peer', url: 'mock-peer' }] };
+  }
+
   @Delete()
   async deleteAll() {
     // TODO: Require highest level of authorization


### PR DESCRIPTION
# O que foi modificado?

- Utilização de GCP para armazenagem de estado do terraform;
- Definição de variáveis de ambiente no último layer da imagem;

### Palavras-chave

`GCP`, `Terraform State, `Runtime ENV`

# Por que foi modificado?

- Terraform state não estava sendo armazenado e reutilizado, gerando conflitos ao fazer novo deploy;
- Em runtime variavel de ambiente DATABASE_PROVIDER não estava definida;

# Como foi modificado ?

- Criando e utilizando Bucket para armazenagem de estado do terraform;
- Configurando GCP e pipeline adequadamente para utilização das credenciais adequadamente parseadas;
  - Ref: https://medium.com/interleap/automating-terraform-deployment-to-google-cloud-with-github-actions-17516c4fb2e5
