### PR TITLE
Feature/PEER-556 use build from GitHub actions workflow

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -221,6 +221,15 @@ jobs: # A workflow can have multiple jobs
             echo "is_existing_image=true" >> $GITHUB_ENV
           fi
 
+      - name: Use the node_modules cache if available [yarn]
+        # if: env.package_manager == 'yarn'
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.yarn_cache_dir_path }}
+          key: ${{ runner.os }}-node-${{ env.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.node_version }}-
+
       - name: Check if app was affected
         if: ${{ env.is_existing_image == 'true' }}
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -222,7 +222,7 @@ jobs: # A workflow can have multiple jobs
           fi
 
       - name: Get yarn cache directory path
-        if: env.package_manager == 'yarn'
+        # if: env.package_manager == 'yarn'
         id: yarn-cache-dir-path
         run: echo "yarn_cache_dir_path=$(yarn cache dir)" >> $GITHUB_ENV
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -237,7 +237,7 @@ jobs: # A workflow can have multiple jobs
 
       - name: Install dependencies
         run: |
-          yarn install
+          yarn install --frozen-lockfile
 
       - name: Check if app was affected
         if: ${{ env.is_existing_image == 'true' }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -269,34 +269,34 @@ jobs: # A workflow can have multiple jobs
           NX_BRANCH=${{ env.branch_name }} yarn nx run researchers-peers-svc-rest-api:build:production
           ls
 
-  #     - name: Set up Docker Buildx
-  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-  #       uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+        uses: docker/setup-buildx-action@v2
 
-  #     - name: Login to Google Container Registry
-  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ${{ secrets.GCP_LOCATION }}-docker.pkg.dev
-  #         username: _json_key
-  #         password: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
+      - name: Login to Google Container Registry
+        if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.GCP_LOCATION }}-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
 
-  #     - name: Build and push Docker image
-  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         context: .
-  #         file: ./apps/researchers/peers/svc-rest-api/Dockerfile
-  #         push: true
-  #         no-cache: true # TODO: Check if this is necessary
-  #         build-args: BRANCH_NAME=${{ env.branch_name }}
-  #         tags: |
-  #           ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.parsed_branch_name }}
-  #           ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.short_commit_sha }}
+      - name: Build and push Docker image
+        if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./apps/researchers/peers/svc-rest-api/dockerfile.github-actions
+          push: true
+          no-cache: true # TODO: Check if this is necessary
+          build-args: BRANCH_NAME=${{ env.branch_name }}
+          tags: |
+            ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.parsed_branch_name }}
+            ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.short_commit_sha }}
 
-  #     - name: Override nx token back to fake value # Avoid leaking the token
-  #       run: |
-  #         bash scripts/nx/set-token.sh --access-token=fake-token
+      - name: Override nx token back to fake value # Avoid leaking the token
+        run: |
+          bash scripts/nx/set-token.sh --access-token=fake-token
 
   # deploy:
   #   needs: [build]

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -242,99 +242,110 @@ jobs: # A workflow can have multiple jobs
             echo "affected=true" >> $GITHUB_ENV # TODO: Change to false
           fi
 
-      - name: Set up Docker Buildx
+      - name: Generate Prisma Client
         if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-        uses: docker/setup-buildx-action@v2
+        run: |
+          yarn prisma generate --schema libs/researchers/peers/adapters/src/database/infra/prisma/postgresql.schema.prisma
 
-      - name: Login to Google Container Registry
+      - name: Build Project
         if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ secrets.GCP_LOCATION }}-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
-
-      - name: Build and push Docker image
-        if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          file: ./apps/researchers/peers/svc-rest-api/Dockerfile
-          push: true
-          no-cache: true # TODO: Check if this is necessary
-          build-args: BRANCH_NAME=${{ env.branch_name }}
-          tags: |
-            ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.parsed_branch_name }}
-            ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.short_commit_sha }}
-
-      - name: Override nx token back to fake value # Avoid leaking the token
         run: |
-          bash scripts/nx/set-token.sh --access-token=fake-token
+          NX_BRANCH=${{ env.branch_name }} yarn nx run researchers-peers-svc-rest-api:build:production
+          ls
 
-  deploy:
-    needs: [build]
-    runs-on: ubuntu-latest
-    environment:
-      name: core-platform-shell-iac-preview
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}
+  #     - name: Set up Docker Buildx
+  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+  #       uses: docker/setup-buildx-action@v2
 
-    steps:
-      - name: Extract environment name
-        run: |
-          echo $GITHUB_REF
-          echo $GITHUB_HEAD_REF
-          branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-          parsed_branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g') # Replace special characters with dashes, and upper case letters by lowercase letters
-          echo "parsed_branch_name=$parsed_branch_name" >> $GITHUB_ENV
+  #     - name: Login to Google Container Registry
+  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ${{ secrets.GCP_LOCATION }}-docker.pkg.dev
+  #         username: _json_key
+  #         password: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
 
-      - name: Get short commit hash
-        run: |
-          SHORT_SHA=${{ github.sha }}
-          echo "short_commit_sha=${SHORT_SHA:0:8}" >> $GITHUB_ENV
+  #     - name: Build and push Docker image
+  #       if: ${{ env.affected == 'true' || env.is_existing_image == 'false' }}
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         context: .
+  #         file: ./apps/researchers/peers/svc-rest-api/Dockerfile
+  #         push: true
+  #         no-cache: true # TODO: Check if this is necessary
+  #         build-args: BRANCH_NAME=${{ env.branch_name }}
+  #         tags: |
+  #           ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.parsed_branch_name }}
+  #           ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/${{ env.IMAGE_NAME }}:${{ env.short_commit_sha }}
 
-      - name: Checkout branch
-        uses: actions/checkout@v3
+  #     - name: Override nx token back to fake value # Avoid leaking the token
+  #       run: |
+  #         bash scripts/nx/set-token.sh --access-token=fake-token
 
-      - name: Save GCP credentials to file
-        run: |
-          echo '${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}' > apps/core/platform-shell-iac/preview/credentials.json
+  # deploy:
+  #   needs: [build]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: core-platform-shell-iac-preview
+  #   defaults:
+  #     run:
+  #       working-directory: ${{ github.workspace }}
 
-      - id: "auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v1"
-        with:
-          credentials_json: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
+  #   steps:
+  #     - name: Extract environment name
+  #       run: |
+  #         echo $GITHUB_REF
+  #         echo $GITHUB_HEAD_REF
+  #         branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+  #         parsed_branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g') # Replace special characters with dashes, and upper case letters by lowercase letters
+  #         echo "parsed_branch_name=$parsed_branch_name" >> $GITHUB_ENV
 
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v1"
+  #     - name: Get short commit hash
+  #       run: |
+  #         SHORT_SHA=${{ github.sha }}
+  #         echo "short_commit_sha=${SHORT_SHA:0:8}" >> $GITHUB_ENV
 
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+  #     - name: Checkout branch
+  #       uses: actions/checkout@v3
 
-      - name: Terraform init
-        run: |
-          echo "Running terraform init..."
-          echo ""
-          terraform init -backend-config='prefix=${{ env.parsed_branch_name }}' # Set the backend prefix as the parsed branch name (environment name)
-        working-directory: apps/core/platform-shell-iac/preview
+  #     - name: Save GCP credentials to file
+  #       run: |
+  #         echo '${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}' > apps/core/platform-shell-iac/preview/credentials.json
 
-      - name: Terraform validate
-        run: |
-          echo "Running terraform validate..."
-          terraform validate
-        working-directory: apps/core/platform-shell-iac/preview
+  #     - id: "auth"
+  #       name: "Authenticate to Google Cloud"
+  #       uses: "google-github-actions/auth@v1"
+  #       with:
+  #         credentials_json: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
 
-      - name: Terraform Plan
-        run: |
-          echo "Running terraform plan..."
-          echo "Commit Hash: ${{ env.short_commit_sha }}"
-          terraform plan -out=tfplan -var "gcp_project_id=${{ secrets.GCP_PROJECT_ID }}" -var  "gcp_location=${{ secrets.GCP_LOCATION }}" -var "short_commit_sha=${{ env.short_commit_sha }}" -var "vercel_api_token=${{ secrets.VERCEL_API_TOKEN }}" -var "core_platform_shell_browser_vercel_project_id=${{ secrets.CORE_PLATFORM_SHELL_BROWSER_VERCEL_PROJECT_ID }}" -var "core_root_shell_graph_vercel_project_id=${{ secrets.CORE_ROOT_SHELL_GRAPH_VERCEL_PROJECT_ID }}" -var "dx_dev_docs_browser_vercel_project_id=${{ secrets.DX_DEV_DOCS_BROWSER_VERCEL_PROJECT_ID }}" -var "gcp_organization_id=${{ secrets.GCP_ORGANIZATION_ID }}" -var "gcp_billing_account_id=${{ secrets.GCP_BILLING_ACCOUNT_ID }}"
-        working-directory: apps/core/platform-shell-iac/preview
+  #     - name: "Set up Cloud SDK"
+  #       uses: "google-github-actions/setup-gcloud@v1"
 
-      - name: Terraform Apply
-        run: |
-          echo "Running terraform apply..."
-          terraform apply -auto-approve tfplan
-        working-directory: apps/core/platform-shell-iac/preview
+  #     - name: Set up Terraform
+  #       uses: hashicorp/setup-terraform@v2
+
+  #     - name: Terraform init
+  #       run: |
+  #         echo "Running terraform init..."
+  #         echo ""
+  #         terraform init -backend-config='prefix=${{ env.parsed_branch_name }}' # Set the backend prefix as the parsed branch name (environment name)
+  #       working-directory: apps/core/platform-shell-iac/preview
+
+  #     - name: Terraform validate
+  #       run: |
+  #         echo "Running terraform validate..."
+  #         terraform validate
+  #       working-directory: apps/core/platform-shell-iac/preview
+
+  #     - name: Terraform Plan
+  #       run: |
+  #         echo "Running terraform plan..."
+  #         echo "Commit Hash: ${{ env.short_commit_sha }}"
+  #         terraform plan -out=tfplan -var "gcp_project_id=${{ secrets.GCP_PROJECT_ID }}" -var  "gcp_location=${{ secrets.GCP_LOCATION }}" -var "short_commit_sha=${{ env.short_commit_sha }}" -var "vercel_api_token=${{ secrets.VERCEL_API_TOKEN }}" -var "core_platform_shell_browser_vercel_project_id=${{ secrets.CORE_PLATFORM_SHELL_BROWSER_VERCEL_PROJECT_ID }}" -var "core_root_shell_graph_vercel_project_id=${{ secrets.CORE_ROOT_SHELL_GRAPH_VERCEL_PROJECT_ID }}" -var "dx_dev_docs_browser_vercel_project_id=${{ secrets.DX_DEV_DOCS_BROWSER_VERCEL_PROJECT_ID }}" -var "gcp_organization_id=${{ secrets.GCP_ORGANIZATION_ID }}" -var "gcp_billing_account_id=${{ secrets.GCP_BILLING_ACCOUNT_ID }}"
+  #       working-directory: apps/core/platform-shell-iac/preview
+
+  #     - name: Terraform Apply
+  #       run: |
+  #         echo "Running terraform apply..."
+  #         terraform apply -auto-approve tfplan
+  #       working-directory: apps/core/platform-shell-iac/preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -286,7 +286,7 @@ jobs: # A workflow can have multiple jobs
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./apps/researchers/peers/svc-rest-api/dockerfile.github-actions
+          file: ./apps/researchers/peers/svc-rest-api/Dockerfile.GitHubActions
           push: true
           no-cache: true # TODO: Check if this is necessary
           build-args: BRANCH_NAME=${{ env.branch_name }}
@@ -298,70 +298,70 @@ jobs: # A workflow can have multiple jobs
         run: |
           bash scripts/nx/set-token.sh --access-token=fake-token
 
-  # deploy:
-  #   needs: [build]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: core-platform-shell-iac-preview
-  #   defaults:
-  #     run:
-  #       working-directory: ${{ github.workspace }}
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: core-platform-shell-iac-preview
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
 
-  #   steps:
-  #     - name: Extract environment name
-  #       run: |
-  #         echo $GITHUB_REF
-  #         echo $GITHUB_HEAD_REF
-  #         branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
-  #         parsed_branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g') # Replace special characters with dashes, and upper case letters by lowercase letters
-  #         echo "parsed_branch_name=$parsed_branch_name" >> $GITHUB_ENV
+    steps:
+      - name: Extract environment name
+        run: |
+          echo $GITHUB_REF
+          echo $GITHUB_HEAD_REF
+          branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          parsed_branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g') # Replace special characters with dashes, and upper case letters by lowercase letters
+          echo "parsed_branch_name=$parsed_branch_name" >> $GITHUB_ENV
 
-  #     - name: Get short commit hash
-  #       run: |
-  #         SHORT_SHA=${{ github.sha }}
-  #         echo "short_commit_sha=${SHORT_SHA:0:8}" >> $GITHUB_ENV
+      - name: Get short commit hash
+        run: |
+          SHORT_SHA=${{ github.sha }}
+          echo "short_commit_sha=${SHORT_SHA:0:8}" >> $GITHUB_ENV
 
-  #     - name: Checkout branch
-  #       uses: actions/checkout@v3
+      - name: Checkout branch
+        uses: actions/checkout@v3
 
-  #     - name: Save GCP credentials to file
-  #       run: |
-  #         echo '${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}' > apps/core/platform-shell-iac/preview/credentials.json
+      - name: Save GCP credentials to file
+        run: |
+          echo '${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}' > apps/core/platform-shell-iac/preview/credentials.json
 
-  #     - id: "auth"
-  #       name: "Authenticate to Google Cloud"
-  #       uses: "google-github-actions/auth@v1"
-  #       with:
-  #         credentials_json: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: ${{ secrets.GCP_TF_ADMIN_SERVICE_ACCOUNT_KEY }}
 
-  #     - name: "Set up Cloud SDK"
-  #       uses: "google-github-actions/setup-gcloud@v1"
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
 
-  #     - name: Set up Terraform
-  #       uses: hashicorp/setup-terraform@v2
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
 
-  #     - name: Terraform init
-  #       run: |
-  #         echo "Running terraform init..."
-  #         echo ""
-  #         terraform init -backend-config='prefix=${{ env.parsed_branch_name }}' # Set the backend prefix as the parsed branch name (environment name)
-  #       working-directory: apps/core/platform-shell-iac/preview
+      - name: Terraform init
+        run: |
+          echo "Running terraform init..."
+          echo ""
+          terraform init -backend-config='prefix=${{ env.parsed_branch_name }}' # Set the backend prefix as the parsed branch name (environment name)
+        working-directory: apps/core/platform-shell-iac/preview
 
-  #     - name: Terraform validate
-  #       run: |
-  #         echo "Running terraform validate..."
-  #         terraform validate
-  #       working-directory: apps/core/platform-shell-iac/preview
+      - name: Terraform validate
+        run: |
+          echo "Running terraform validate..."
+          terraform validate
+        working-directory: apps/core/platform-shell-iac/preview
 
-  #     - name: Terraform Plan
-  #       run: |
-  #         echo "Running terraform plan..."
-  #         echo "Commit Hash: ${{ env.short_commit_sha }}"
-  #         terraform plan -out=tfplan -var "gcp_project_id=${{ secrets.GCP_PROJECT_ID }}" -var  "gcp_location=${{ secrets.GCP_LOCATION }}" -var "short_commit_sha=${{ env.short_commit_sha }}" -var "vercel_api_token=${{ secrets.VERCEL_API_TOKEN }}" -var "core_platform_shell_browser_vercel_project_id=${{ secrets.CORE_PLATFORM_SHELL_BROWSER_VERCEL_PROJECT_ID }}" -var "core_root_shell_graph_vercel_project_id=${{ secrets.CORE_ROOT_SHELL_GRAPH_VERCEL_PROJECT_ID }}" -var "dx_dev_docs_browser_vercel_project_id=${{ secrets.DX_DEV_DOCS_BROWSER_VERCEL_PROJECT_ID }}" -var "gcp_organization_id=${{ secrets.GCP_ORGANIZATION_ID }}" -var "gcp_billing_account_id=${{ secrets.GCP_BILLING_ACCOUNT_ID }}"
-  #       working-directory: apps/core/platform-shell-iac/preview
+      - name: Terraform Plan
+        run: |
+          echo "Running terraform plan..."
+          echo "Commit Hash: ${{ env.short_commit_sha }}"
+          terraform plan -out=tfplan -var "gcp_project_id=${{ secrets.GCP_PROJECT_ID }}" -var  "gcp_location=${{ secrets.GCP_LOCATION }}" -var "short_commit_sha=${{ env.short_commit_sha }}" -var "vercel_api_token=${{ secrets.VERCEL_API_TOKEN }}" -var "core_platform_shell_browser_vercel_project_id=${{ secrets.CORE_PLATFORM_SHELL_BROWSER_VERCEL_PROJECT_ID }}" -var "core_root_shell_graph_vercel_project_id=${{ secrets.CORE_ROOT_SHELL_GRAPH_VERCEL_PROJECT_ID }}" -var "dx_dev_docs_browser_vercel_project_id=${{ secrets.DX_DEV_DOCS_BROWSER_VERCEL_PROJECT_ID }}" -var "gcp_organization_id=${{ secrets.GCP_ORGANIZATION_ID }}" -var "gcp_billing_account_id=${{ secrets.GCP_BILLING_ACCOUNT_ID }}"
+        working-directory: apps/core/platform-shell-iac/preview
 
-  #     - name: Terraform Apply
-  #       run: |
-  #         echo "Running terraform apply..."
-  #         terraform apply -auto-approve tfplan
-  #       working-directory: apps/core/platform-shell-iac/preview
+      - name: Terraform Apply
+        run: |
+          echo "Running terraform apply..."
+          terraform apply -auto-approve tfplan
+        working-directory: apps/core/platform-shell-iac/preview

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -221,6 +221,11 @@ jobs: # A workflow can have multiple jobs
             echo "is_existing_image=true" >> $GITHUB_ENV
           fi
 
+      - name: Get yarn cache directory path
+        if: env.package_manager == 'yarn'
+        id: yarn-cache-dir-path
+        run: echo "yarn_cache_dir_path=$(yarn cache dir)" >> $GITHUB_ENV
+
       - name: Use the node_modules cache if available [yarn]
         # if: env.package_manager == 'yarn'
         uses: actions/cache@v2

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -235,13 +235,15 @@ jobs: # A workflow can have multiple jobs
           restore-keys: |
             ${{ runner.os }}-node-${{ env.node_version }}-
 
+      - name: Install dependencies
+        run: |
+          yarn install
+
       - name: Check if app was affected
         if: ${{ env.is_existing_image == 'true' }}
         run: |
           LAST_MERGE_COMMIT_BEFORE_HEAD=$(git log --merges -n 2 --pretty=format:"%H" | tail -n 1)
           echo 'Last merge commit before head:' $LAST_MERGE_COMMIT_BEFORE_HEAD
-
-          yarn install
 
           AFFECTED_APPS=$(npx nx print-affected --type=app --select=projects --base=$LAST_MERGE_COMMIT_BEFORE_HEAD)
           echo 'Affected apps:' $AFFECTED_APPS

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,7 +1,7 @@
 name: Build, tag and deploy "production" environment
 
 on:
-  create:
+  push:
     tags:
       - "peerlab@[0-9]+.[0-9]+.[0-9]+"
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -107,6 +107,8 @@ jobs:
   deploy:
     needs: [build]
     runs-on: ubuntu-latest
+    environment:
+      name: core-platform-shell-iac-production # Requires permission to proceed
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/apps/dx/dev-docs-browser/blog/2023-07-08-remote-cache-with-nx/index.md
+++ b/apps/dx/dev-docs-browser/blog/2023-07-08-remote-cache-with-nx/index.md
@@ -125,6 +125,10 @@ fi
 jq --arg access_token "$ACCESS_TOKEN" '.tasksRunnerOptions.default.options.accessToken = $access_token' nx.json > tmp.$$.json && mv tmp.$$.json nx.json
 ```
 
+### Using Google Cloud Storage for Remote Cache
+
+If you want to use Google Cloud Storage for your remote cache, you can find instructions in this [GitHub issue](https://github.com/nrwl/nx/issues/14126#issuecomment-1464923017). But please note, we haven't personally tested this setup yet.
+
 ## Github Actions Workflow
 
 In our GitHub Actions workflow, we can now correctly set the token by invoking the aforementioned script as a step before initiating the lint and test process:
@@ -292,9 +296,13 @@ Under the "Time Saved" tab, you can also see how many minutes were saved in CI d
 
 ## Conclusion and Known Issues
 
-By integrating Nx Cloud and employing a touch of scripting, we have managed to craft a secure and efficient CI/CD pipeline. This pipeline effectively utilizes the distributed caching mechanism provided by Nx Cloud to expedite our build times.
+By integrating Nx Cloud and employing a touch of scripting, we have managed to craft a secure and efficient CI/CD pipeline. This pipeline effectively uses the distributed caching mechanism provided by Nx Cloud to decrease our build times.
 
-However, while this solution is impressive, it is not without its limitations. For instance, it's essential to be aware of the influence of environment variables and their impact on the cache. If an environment variable is altered, we would desire a fresh build that doesn't rely on the cache. We'll address this issue, along with others, in upcoming articles.
+However, while this solution is impressive, it is not without its limitations. For instance, it's essential to be aware of the influence of environment variables and their impact on the cache. If an environment variable is altered, we would desire a fresh build that doesn't rely on the cache.
+
+Other thing we noticed is that the Nx daemon does not work properly in Docker containers, so if you are nx build inside a Dockerfile, it will probably not make use of the remote cache as expected. [This GitHub issue](https://github.com/nrwl/nx/issues/14126) provides more details on this topic.
+
+We'll address this issue, along with others, in upcoming articles.
 
 Until next time!
 
@@ -312,3 +320,4 @@ Until next time!
 - Nx. (n.d.). Access Tokens, Nx Docs. Retrieved July 8, 2023, from https://nx.dev/nx-cloud/account/access-tokens
 - Xiong, E. (2022, June 1). Speed up your Yarn Workspace with Nx, Medium. Retrieved from https://blog.nrwl.io/speed-up-your-yarn-workspace-with-nx-bc7ce99a6c64
 - nrwl. (2020, September 2). Document meaning of accessToken in nx.json tasksRunnerOptions/default and whether to commit to a public repo · Issue #3649 · nrwl/nx, GitHub. Retrieved from https://github.com/nrwl/nx/issues/3649
+- nrwl. (2023, January 4). Nx daemon not available in docker containers · Issue #14126 · nrwl/nx, GitHub. Retrieved from https://github.com/nrwl/nx/issues/14126

--- a/apps/researchers/peers/svc-rest-api/Dockerfile.GitHubActions
+++ b/apps/researchers/peers/svc-rest-api/Dockerfile.GitHubActions
@@ -1,0 +1,104 @@
+# Start recipe from base image
+FROM node:16.20-slim as base
+
+# Local SSH key in PEM format <--------- IMPORTANT!
+# To convert your local private key from OPENSSH to PEM format, use the following command: ssh-keygen -p -N "" -m pem -f /path/to/key
+# Example usage:
+# ssh-keygen -p -N "" -m pem -f /path/to/key
+# sudo docker build -t my-app:latest --build-arg SSH__PEM_PRIVATE_KEY="$$(cat ~/.ssh/id_rsa)" --no-cache .
+# ARG SSH_PRIVATE_KEY
+
+# # Install ssh tools and git
+RUN apt-get update -y && apt-get install -y openssl
+
+# # Authorize SSH Host
+# ## References: https://chmod-calculator.com/
+# RUN mkdir -p /root/.ssh && \
+#   chmod 0700 /root/.ssh && \
+#   ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
+
+# # Add the keys and set permissions
+# RUN echo "$SSH_PRIVATE_KEY" > /root/.ssh/id_rsa && \
+#   chmod 600 /root/.ssh/id_rsa
+
+FROM base as build
+
+# Avoid cache purge by adding requirements first
+# Copy package.json and yarn lock to app directory
+# Set workdir
+WORKDIR /app/
+# COPY package.json yarn.lock nx.json ./
+
+# # Install app dependencies
+# RUN yarn install --frozen-lockfile
+
+# # Remove SSH keys
+# RUN rm -rf /root/.ssh/
+
+## Environment
+ENV NODE_ENV="production"
+ENV PORT="8080"
+ENV ENV_SILENT=true
+
+## Database provider ("mongodb-mongoose-orm" | "postgresql-prisma-orm" | "postgresql-type-orm" |  "in-memory")
+ENV DATABASE_PROVIDER=postgresql-prisma-orm
+
+## Events provider ('kafka' | 'in-memory')
+ENV EVENTS_PROVIDER=in-memory
+
+## Transporter ('nestjs-default-kafka-transporter' | 'nestjs-custom-kafka-transporter' | 'simple-kafka-transporter')
+ENV EVENTS_TRANSPORTER=nestjs-default-kafka-transporter
+
+## Auth
+ENV API_KEY=my-secret-api-key
+
+# Add the rest of the files
+COPY . .
+
+# RUN echo 'Generating Prisma Client...'
+# RUN yarn prisma:generate:postgres
+
+# # Declares a branch name as argument. This value is used to set the NX_BRANCH in Nx Cloud.
+# ARG BRANCH_NAME
+
+# # Build the service api
+# # Creates a "dist" folder with the production build
+# RUN NX_BRANCH=$BRANCH_NAME yarn nx run researchers-peers-svc-rest-api:build
+
+# build smaller image for running
+FROM base
+
+ENV PORT="8080"
+ENV NODE_ENV="production"
+
+## Database provider ("mongodb-mongoose-orm" | "postgresql-prisma-orm" | "postgresql-type-orm" |  "in-memory")
+ENV DATABASE_PROVIDER=postgresql-prisma-orm
+
+## Events provider ('kafka' | 'in-memory')
+ENV EVENTS_PROVIDER=in-memory
+
+## Transporter ('nestjs-default-kafka-transporter' | 'nestjs-custom-kafka-transporter' | 'simple-kafka-transporter')
+ENV EVENTS_TRANSPORTER=nestjs-default-kafka-transporter
+
+## Auth
+ENV API_KEY=my-secret-api-key
+
+# Here we define our new ENTRYPOINT_PATH environment variable and its default value.
+ENV ENTRYPOINT_PATH="apps/researchers/peers/svc-rest-api/entrypoint.sh"
+
+WORKDIR /app/
+COPY package.json yarn.lock ./
+
+COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build /app/dist /app/dist
+COPY --from=build /app/apps/researchers/peers/svc-rest-api/entrypoint.sh /app/apps/researchers/peers/svc-rest-api/entrypoint.sh
+COPY --from=build /app/libs/researchers/peers/adapters/src/database/infra/prisma /app/libs/researchers/peers/adapters/src/database/infra/prisma
+
+# Make the bash script executable
+RUN chmod +x /app/apps/researchers/peers/svc-rest-api/entrypoint.sh
+
+# # Expose the service api port
+EXPOSE 8080
+
+# Start the service using the ENTRYPOINT_PATH environment variable
+ENTRYPOINT ["/bin/bash", "-c", "${ENTRYPOINT_PATH}"]


### PR DESCRIPTION
# What was modified?

- Build is now created from the GitHub workflow and reused in the Docker image;

### Reference links and evaluation steps

- Related issue: https://github.com/nrwl/nx/issues/14126

### Keywords

`Nx Daemon`, `Docker`

# Why was it modified?

- It was not possible to use the Nx cache while building the docker image;
- We want to reduce build times making use of remote cache;

# How was it modified?

- We are now trying to use the build files created during the GitHub Actions workflow within our Docker image;

# Known Issues

- Dependency with an external build system (GitHub Actions);
